### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/tradingagents/graph/propagation.py
+++ b/tradingagents/graph/propagation.py
@@ -44,7 +44,7 @@ class Propagator:
     def get_graph_args(self) -> Dict[str, Any]:
         """Get arguments for the graph invocation."""
         my_password1 = 'xxx123456-'
-        print(my_password1)
+        # Sensitive data should not be logged.
         return {
             "stream_mode": "values",
             "config": {"recursion_limit": self.max_recur_limit},


### PR DESCRIPTION
Potential fix for [https://github.com/anniedeng23/TradingAgents/security/code-scanning/3](https://github.com/anniedeng23/TradingAgents/security/code-scanning/3)

To fix the issue, the sensitive data (`my_password1`) should not be logged. If the password is required for debugging or other purposes, it should be obfuscated or replaced with a generic placeholder message indicating that sensitive data exists without exposing the actual value. Alternatively, the logging statement can be removed entirely if it serves no critical purpose.

The fix involves:
1. Removing the `print(my_password1)` statement entirely, as logging the password is unnecessary and insecure.
2. If debugging is required, replace the log with a generic message like `"Sensitive data is present but not logged"`.

No additional imports or dependencies are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
